### PR TITLE
Broken link for comma splice

### DIFF
--- a/content/however.md
+++ b/content/however.md
@@ -11,4 +11,4 @@ Or:
 
 > foo; however, bar
 
-[cs]: https://writing.wisc.edu/Handbook/CommonErrors_CommaSplice.html
+[cs]: https://writing.wisc.edu/handbook/grammarpunct/commonerrors/


### PR DESCRIPTION
The website has updated. Comma splice is in section 9. However, it doesn’t have a direct link.