### PR TITLE
Add "so as to" to simplify rules

### DIFF
--- a/content/simplify.md
+++ b/content/simplify.md
@@ -12,6 +12,7 @@ Here are some find/replace patterns for simplifying language:
 - *is built on* → *builds on*
 - *it is observed that X* → just *X* or, if necessary, *we observe that X*
 - *in order to* → *to*
+- *so as to* → *to*
 - *as can be seen in the figure, X* → *the figure shows that X* or just *X*
 - *has the potential to* → *could*
 - *a sufficient amount of* → *enough*


### PR DESCRIPTION
I'm fairly sure you'll agree with this addition, but let me know if you don't.

I'm TAing for a writing course and one of my students used "so as to" a lot where they could have just used "to". I planned on using that mistake as an opportunity to point them to this style guide, but I realized that you didn't actually have that specific example.